### PR TITLE
chore: fix misleading typo

### DIFF
--- a/pages/o/[orgSlug]/[endpointId]/index.vue
+++ b/pages/o/[orgSlug]/[endpointId]/index.vue
@@ -268,7 +268,7 @@ async function getMessageDeliveries() {
                   </UTooltip>
                 </div>
                 <div class="flex flex-row gap-2 items-center">
-                  <span class="text-sm text-gray-500">Rounting: </span>
+                  <span class="text-sm text-gray-500">Routing: </span>
                   <UTooltip
                     text="Click to edit"
                     class="w-fit flex flex-row gap-2 items-center"


### PR DESCRIPTION
Why this PR:
- This PR Fixes a misleading typo in the Routing Option